### PR TITLE
Fix - Added missing inertial tags to robot 

### DIFF
--- a/src/collaborative-robotic-sanding/abb_irb6700_support/urdf/irb6700_200_260_macro.xacro
+++ b/src/collaborative-robotic-sanding/abb_irb6700_support/urdf/irb6700_200_260_macro.xacro
@@ -25,6 +25,11 @@
         </geometry>
         <xacro:material_abb_yellow/>
       </collision>
+      <inertial>
+        <mass value="12.93"/>
+        <origin rpy="0 1.57079632679 0" xyz="-0.3059856723 0.0 0.175"/>
+        <inertia ixx="0.421716012238" ixy="0.0" ixz="0.0" iyy="0.421716012238" iyz="0.0" izz="0.036365625"/>
+      </inertial>
     </link>
     <link name="${prefix}link_1">
       <visual>
@@ -41,6 +46,11 @@
         </geometry>
         <xacro:material_abb_yellow/>
       </collision>
+      <inertial>
+        <mass value="12.93"/>
+        <origin rpy="0 1.57079632679 0" xyz="-0.3059856723 0.0 0.175"/>
+        <inertia ixx="0.421716012238" ixy="0.0" ixz="0.0" iyy="0.421716012238" iyz="0.0" izz="0.036365625"/>
+      </inertial>
     </link>
     <link name="${prefix}cylinder">
       <visual>
@@ -57,6 +67,11 @@
         </geometry>
         <xacro:material_abb_yellow/>
       </collision>
+      <inertial>
+        <mass value="12.93"/>
+        <origin rpy="0 1.57079632679 0" xyz="-0.3059856723 0.0 0.175"/>
+        <inertia ixx="0.421716012238" ixy="0.0" ixz="0.0" iyy="0.421716012238" iyz="0.0" izz="0.036365625"/>
+      </inertial>
     </link>
     <link name="${prefix}piston">
       <visual>
@@ -73,6 +88,11 @@
         </geometry>
         <xacro:material_abb_yellow/>
       </collision>
+      <inertial>
+        <mass value="12.93"/>
+        <origin rpy="0 1.57079632679 0" xyz="-0.3059856723 0.0 0.175"/>
+        <inertia ixx="0.421716012238" ixy="0.0" ixz="0.0" iyy="0.421716012238" iyz="0.0" izz="0.036365625"/>
+      </inertial>
     </link>
     <link name="${prefix}link_2">
       <visual>
@@ -89,6 +109,11 @@
         </geometry>
         <xacro:material_abb_yellow/>
       </collision>
+      <inertial>
+        <mass value="12.93"/>
+        <origin rpy="0 1.57079632679 0" xyz="-0.3059856723 0.0 0.175"/>
+        <inertia ixx="0.421716012238" ixy="0.0" ixz="0.0" iyy="0.421716012238" iyz="0.0" izz="0.036365625"/>
+      </inertial>
     </link>
     <link name="${prefix}link_3">
       <visual>
@@ -105,6 +130,11 @@
         </geometry>
         <xacro:material_abb_yellow/>
       </collision>
+      <inertial>
+        <mass value="12.93"/>
+        <origin rpy="0 1.57079632679 0" xyz="-0.3059856723 0.0 0.175"/>
+        <inertia ixx="0.421716012238" ixy="0.0" ixz="0.0" iyy="0.421716012238" iyz="0.0" izz="0.036365625"/>
+      </inertial>
     </link>
     <link name="${prefix}link_4">
       <visual>
@@ -121,6 +151,11 @@
         </geometry>
         <xacro:material_abb_yellow/>
       </collision>
+      <inertial>
+        <mass value="12.93"/>
+        <origin rpy="0 1.57079632679 0" xyz="-0.3059856723 0.0 0.175"/>
+        <inertia ixx="0.421716012238" ixy="0.0" ixz="0.0" iyy="0.421716012238" iyz="0.0" izz="0.036365625"/>
+      </inertial>
     </link>
     <link name="${prefix}link_5">
       <visual>
@@ -137,6 +172,11 @@
         </geometry>
         <xacro:material_abb_yellow/>
       </collision>
+      <inertial>
+        <mass value="12.93"/>
+        <origin rpy="0 1.57079632679 0" xyz="-0.3059856723 0.0 0.175"/>
+        <inertia ixx="0.421716012238" ixy="0.0" ixz="0.0" iyy="0.421716012238" iyz="0.0" izz="0.036365625"/>
+      </inertial>
     </link>
     <link name="${prefix}link_6">
       <visual>
@@ -153,6 +193,11 @@
         </geometry>
         <xacro:material_abb_yellow/>
       </collision>
+      <inertial>
+        <mass value="12.93"/>
+        <origin rpy="0 1.57079632679 0" xyz="-0.3059856723 0.0 0.175"/>
+        <inertia ixx="0.421716012238" ixy="0.0" ixz="0.0" iyy="0.421716012238" iyz="0.0" izz="0.036365625"/>
+      </inertial>
     </link>
     <!--add e-e-->
     <link name="${prefix}ef">
@@ -183,6 +228,7 @@
       <child link="${prefix}link_1" />
       <axis xyz="0 0 1" />
       <limit lower="-${radians(170)}" upper="${radians(170)}" effort="0" velocity="${radians(110)}" />
+      <dynamics damping="0.0" friction="0.0"/>
     </joint>
     <joint name="${prefix}joint_2" type="revolute">
       <origin xyz="0.32 0 0" rpy="0 0 0" />
@@ -190,6 +236,7 @@
       <child link="${prefix}link_2" />
       <axis xyz="0 1 0" />
       <limit lower="-${radians(65)}" upper="${radians(85)}" effort="0" velocity="${radians(110)}" />
+      <dynamics damping="0.0" friction="0.0"/>
     </joint>
     <joint name="${prefix}joint_3" type="revolute">
       <origin xyz="0 0 1.125" rpy="0 0 0" />
@@ -197,6 +244,7 @@
       <child link="${prefix}link_3" />
       <axis xyz="0 1 0" />
       <limit lower="-${radians(180)}" upper="${radians(70)}" effort="0" velocity="${radians(110)}" />
+      <dynamics damping="0.0" friction="0.0"/>
     </joint>
     <joint name="${prefix}joint_4" type="revolute">
       <origin xyz="0 0 0.2" rpy="0 0 0" />
@@ -204,6 +252,7 @@
       <child link="${prefix}link_4" />
       <axis xyz="1 0 0" />
       <limit lower="-${radians(300)}" upper="${radians(300)}" effort="0" velocity="${radians(190)}" />
+      <dynamics damping="0.0" friction="0.0"/>
     </joint>
     <joint name="${prefix}joint_5" type="revolute">
       <origin xyz="1.1425 0 0" rpy="0 0 0" />
@@ -211,6 +260,7 @@
       <child link="${prefix}link_5" />
       <axis xyz="0 1 0" />
       <limit lower="-${radians(130)}" upper="${radians(130)}" effort="0" velocity="${radians(150)}" />
+      <dynamics damping="0.0" friction="0.0"/>
     </joint>
     <joint name="${prefix}joint_6" type="revolute">
       <origin xyz="0.2 0 0" rpy="0 0 0" />
@@ -218,8 +268,9 @@
       <child link="${prefix}link_6" />
       <axis xyz="1 0 0" />
       <limit lower="-${radians(360)}" upper="${radians(360)}" effort="0" velocity="${radians(210)}" />
+      <dynamics damping="0.0" friction="0.0"/>
     </joint>
-    <joint name="${prefix}cylinder_joint" type="revolute">
+    <joint name="${prefix}cylinder_joint" type="fixed">
       <origin xyz="-0.349 -0.194 -0.142" rpy="0 0 0" />
       <parent link="${prefix}link_1" />
       <child link="${prefix}cylinder" />
@@ -227,7 +278,7 @@
       <mimic joint="${prefix}joint_2" multiplier="-0.25"/>
       <limit lower="-${radians(65*0.25)}" upper="${radians(85*0.25)}" effort="0" velocity="100" />
     </joint>
-    <joint name="${prefix}piston_joint" type="prismatic">
+    <joint name="${prefix}piston_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0.20897 0 -${radians(90)}" />
       <parent link="${prefix}cylinder" />
       <child link="${prefix}piston" />
@@ -445,8 +496,8 @@
 
         <plugin name='gazebo_ros_joint_state_publisher' filename='libgazebo_ros_joint_state_publisher.so'>
           <ros>
-              <namespace>/test</namespace>
-              <argument>joint_states:=joint_states</argument>
+              <namespace>crs</namespace>
+              <argument>--ros-args --remap  joint_states:=${prefix}/joint_states</argument>
 	     
           </ros>
           <update_rate>50</update_rate>
@@ -457,15 +508,15 @@
           <joint_name>${prefix}joint_4</joint_name>
           <joint_name>${prefix}joint_5</joint_name>
           <joint_name>${prefix}joint_6</joint_name>
-		  <joint_name>${prefix}cylinder_joint</joint_name>
-          <joint_name>${prefix}piston_joint</joint_name>
+		      <!--<joint_name>${prefix}cylinder_joint</joint_name>
+          <joint_name>${prefix}piston_joint</joint_name>-->
 
         </plugin>
 
         <plugin name='crs_gazebo_plugins_joint_pose_trajectory' filename='libcrs_gazebo_plugins_joint_pose_trajectory.so'>
             <ros>
               <namespace>sim</namespace>
-              <argument>follow_joint_trajectory:=${prefix}follow_joint_trajectory</argument>
+              <argument>--ros-args --remap follow_joint_trajectory:=${prefix}follow_joint_trajectory</argument>
             </ros>
             <update_rate>20</update_rate>
         </plugin>

--- a/src/collaborative-robotic-sanding/crs_support/launch/abb_irb6700_environment_launch.launch.py
+++ b/src/collaborative-robotic-sanding/crs_support/launch/abb_irb6700_environment_launch.launch.py
@@ -38,11 +38,13 @@ def launch_setup(context, *args, **kwargs):
     cmd_dict = {cmd2 : True, cmd3: True, cmd4 : False}
     
     # check if soft link exists
-    gazebo_model_path = os.path.join(os.environ['HOME'],'.gazebo', 'models', 'abb_irb6700_support')
-    crs_model_path = get_package_share_directory('abb_irb6700_support')
-    cmd1 = 'ln -s %s %s'%(crs_model_path, gazebo_model_path)
-    if not os.path.exists(gazebo_model_path):
-        cmd_dict[cmd1] = True        
+    gazebo_model_packages = ['abb_irb6700_support', 'fanuc_r2000ic_support']
+    for gm_pkg in gazebo_model_packages:
+      gazebo_model_path = os.path.join(os.environ['HOME'],'.gazebo', 'models', gm_pkg)
+      crs_model_path = get_package_share_directory(gm_pkg)
+      cmd1 = 'ln -s %s %s'%(crs_model_path, gazebo_model_path)
+      if not os.path.exists(gazebo_model_path):
+          cmd_dict[cmd1] = True        
     
     for cmd, req_ in cmd_dict.items():   
         try:       
@@ -62,19 +64,19 @@ def launch_setup(context, *args, **kwargs):
     )
     
     spawner1 = launch_ros.actions.Node(
-        node_name='spawn_node',
-        #node_namespace = [launch.substitutions.LaunchConfiguration('global_ns')],
+        name='spawn_node',
+        #namespace = [launch.substitutions.LaunchConfiguration('global_ns')],
         package='gazebo_ros',
-        node_executable='spawn_entity.py',
+        executable='spawn_entity.py',
         arguments=['-entity', 'robot', '-x', '0', '-y', '0', '-z', '0', '-file', urdf],
         condition = launch.conditions.IfCondition(launch.substitutions.LaunchConfiguration('sim_robot'))
         )
 
     motion_planning_server = launch_ros.actions.Node(
-        node_executable='crs_motion_planning_motion_planning_server',
+        executable='crs_motion_planning_motion_planning_server',
         package='crs_motion_planning',
-        node_name='motion_planning_server',
-        #node_namespace = [launch.substitutions.LaunchConfiguration('global_ns')],
+        name='motion_planning_server',
+        #namespace = [launch.substitutions.LaunchConfiguration('global_ns')],
 #        prefix= 'xterm -e',
         output='screen',
         parameters=[{
@@ -107,9 +109,9 @@ def launch_setup(context, *args, **kwargs):
     '''
 
     test_process_planner = launch_ros.actions.Node(
-        node_executable='crs_motion_planning_process_planner_test',
+        executable='crs_motion_planning_process_planner_test',
         package='crs_motion_planning',
-        node_name='process_planner_test',
+        name='process_planner_test',
         output='screen',
         parameters=[{'urdf_path': urdf,
         'srdf_path': srdf,
@@ -128,16 +130,16 @@ def launch_setup(context, *args, **kwargs):
         'set_trajopt_verbose': False}])
 
     ur_comms_node = launch_ros.actions.Node(
-        node_executable='crs_robot_comms_ur_comms',
+        executable='crs_robot_comms_ur_comms',
         package='crs_robot_comms',
-        node_name='ur_comms_node',
+        name='ur_comms_node',
         output='screen',
         condition = launch.conditions.UnlessCondition(launch.substitutions.LaunchConfiguration('sim_robot')))
 
     ur_comms_node_sim = launch_ros.actions.Node(
-        node_executable='crs_robot_comms_ur_comms_sim',
+        executable='crs_robot_comms_ur_comms_sim',
         package='crs_robot_comms',
-        node_name='ur_comms_sim_node',
+        name='ur_comms_sim_node',
         output='screen',
         condition = launch.conditions.IfCondition(launch.substitutions.LaunchConfiguration('sim_robot')))
     
@@ -145,10 +147,10 @@ def launch_setup(context, *args, **kwargs):
     return [
         # environment
         launch_ros.actions.Node(
-             node_name = ['env_node'],
-             #node_namespace = [launch.substitutions.LaunchConfiguration('global_ns')],
+             name = ['env_node'],
+             #namespace = [launch.substitutions.LaunchConfiguration('global_ns')],
              package='tesseract_monitoring',
-             node_executable='tesseract_monitoring_environment_node',
+             executable='tesseract_monitoring_environment_node',
              output='screen',
              parameters=[{'use_sim_time': launch.substitutions.LaunchConfiguration('sim_robot'),
              'desc_param': 'robot_description',


### PR DESCRIPTION
Adding the <inertia> tags to the links in the  xacro file allows gazebo to properly instantiate the robot model and publish the joint states

